### PR TITLE
Move Openfire execution scripts to this repo

### DIFF
--- a/.circleci/scripts/startCIServer.sh
+++ b/.circleci/scripts/startCIServer.sh
@@ -49,12 +49,12 @@ function launchOpenfire {
 	chmod +x "${OPENFIRE_SHELL_SCRIPT}"
 
 	# Replace standard config with demoboot config
-	rm -f ${BASEDIR}/conf/openfire.xml
-	cp ${BASEDIR}/conf/openfire-demoboot.xml \
-		${BASEDIR}/conf/openfire.xml
+	rm -f "${BASEDIR}/conf/openfire.xml"
+	cp "${BASEDIR}/conf/openfire-demoboot.xml" \
+		"${BASEDIR}/conf/openfire.xml"
 
 	# Replace the default XMPP domain name ('example.org') that's in the demoboot config with the configured domain name.
-	sed -i -e 's/example.org/'"${HOST}"'/g' ${BASEDIR}/conf/openfire.xml
+	sed -i -e 's/example.org/'"${HOST}"'/g' "${BASEDIR}/conf/openfire.xml"
 
 	echo "Starting Openfire…"
 	"${OPENFIRE_SHELL_SCRIPT}" 

--- a/.circleci/scripts/startCIServer.sh
+++ b/.circleci/scripts/startCIServer.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Starts an Openfire server (used in Continuous integration testing)
+set -euo pipefail
+
+HOST='example.org'
+
+usage()
+{
+	echo "Usage: $0 [-i IPADDRESS] [-h HOST] [-b BASEDIR]"
+	echo "    -i: Set a hosts file for the given IP and host (or for example.com if running locally). Reverted at exit."
+	echo "    -h: The network name for the Openfire under test, which will be used for both the hostname as the XMPP domain name (default: example.org)"
+	echo "    -b: The base directory of the distribution that is to be started"
+	exit 2
+}
+
+while getopts h:i:b: OPTION "$@"; do
+	case $OPTION in
+		h)
+			HOST="${OPTARG}"
+			;;
+		i)
+			IPADDRESS="${OPTARG}"
+			;;
+		b)
+			BASEDIR="${OPTARG}"
+			;;
+		\? ) usage;;
+        :  ) usage;;
+        *  ) usage;;
+	esac
+done
+
+function setHostsFile {
+	if [[ -n "${IPADDRESS-}" ]]; then
+		echo "Setting hosts file for local running. This may prompt for sudo."
+		sudo /bin/sh -c "echo \"$IPADDRESS $HOST\" >> /etc/hosts"
+	fi
+}
+
+function launchOpenfire {
+	declare -r OPENFIRE_SHELL_SCRIPT="${BASEDIR}/bin/openfire.sh"
+
+	if [[ ! -f "${OPENFIRE_SHELL_SCRIPT}" ]]; then
+		echo "Unable to find Openfire distribution in ${BASEDIR} (this file did not exist: ${OPENFIRE_SHELL_SCRIPT} )"
+		exit 1
+	fi
+
+	# Ensure script is executable
+	chmod +x "${OPENFIRE_SHELL_SCRIPT}"
+
+	# Replace standard config with demoboot config
+	rm -f ${BASEDIR}/conf/openfire.xml
+	cp ${BASEDIR}/conf/openfire-demoboot.xml \
+		${BASEDIR}/conf/openfire.xml
+
+	# Replace the default XMPP domain name ('example.org') that's in the demoboot config with the configured domain name.
+	sed -i -e 's/example.org/'"${HOST}"'/g' ${BASEDIR}/conf/openfire.xml
+
+	echo "Starting Openfire…"
+	"${OPENFIRE_SHELL_SCRIPT}" 
+}
+
+if [[ -n "${IPADDRESS-}" ]]; then
+	setHostsFile
+fi
+
+launchOpenfire

--- a/.circleci/scripts/stopCIServer.sh
+++ b/.circleci/scripts/stopCIServer.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Stops an Openfire server (used in Continuous integration testing)
+set -euo pipefail
+
+HOST='example.org'
+
+usage()
+{
+	echo "Usage: $0 [-i IPADDRESS] [-h HOST]"
+	echo "    -i: Set a hosts file for the given IP and host (or for example.com if running locally). Reverted at exit."
+	echo "    -h: The network name for the Openfire under test, which will be used for both the hostname as the XMPP domain name."
+
+	exit 2
+}
+
+while getopts h:i: OPTION "$@"; do
+	case $OPTION in
+		h)
+			HOST="${OPTARG}"
+			;;
+		i)
+			IPADDRESS="${OPTARG}"
+			;;
+		\? ) usage;;
+        :  ) usage;;
+        *  ) usage;;
+	esac
+done
+
+if [[ -n "${IPADDRESS-}" ]]; then
+    echo "Resetting hosts file after local running. This may prompt for sudo."
+    sudo sed -i'.original' "/$IPADDRESS $HOST/d" /etc/hosts
+fi
+
+echo "Stopping Openfire"
+pkill -f openfire.lib #TODO: Can this be made more future-proof against changes in the start script?

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,23 +29,12 @@ jobs:
           name: Fetch Openfire
           command: curl -L "https://github.com/igniterealtime/Openfire/releases/download/v4.8.1/openfire_4_8_1.tar.gz" -o openfire.tar.gz
       - run:
-          name: Fetch Openfire utility scripts
-          command: |
-            mkdir -p scripts
-            cd scripts
-            git init
-            git remote add -f origin git@github.com:XMPP-Interop-Testing/Openfire-CircleCI.git
-            git config core.sparseCheckout true
-            echo ".github" >> .git/info/sparse-checkout
-            git pull origin main
-            cd ..
-      - run:
           name: 'Extract Openfire'
           command: tar -xzf openfire.tar.gz
       - run:
           name: 'Run Openfire'
           command: |
-            scripts/.github/actions/startserver-action/startCIServer.sh -i "127.0.0.1" -h "example.org" -b "openfire"
+            .circleci/scripts/startCIServer.sh -i "127.0.0.1" -h "example.org" -b "openfire"
             sleep 6000
           background: true
       - run:


### PR DESCRIPTION
After squashing the Openfire-CircleCI repo, jobs here failed because it depended on that repo for the Openfire start script.

I've copied it here to account for future stability.