### PR TITLE
Drop option to specifiy the version of the underlying smack-sint-server-extensions jar file to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
 .DS_Store
+.idea

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -2,10 +2,6 @@ description: >
   Runs tests using the provided configuration parameters
 
 parameters:
-  version:
-    type: string
-    description: 'The version of the underlying smack-sint-server-extensions jar file to use.'
-    default: '1.1'
   ipAddress:
     type: string
     description: 'The IP address of the server under test'
@@ -34,7 +30,6 @@ parameters:
 steps:
   - run:
       environment:
-        PARAM_VERSION: <<parameters.version>>
         PARAM_IP_ADDRESS: <<parameters.ipAddress>>
         PARAM_DOMAIN: <<parameters.domain>>
         PARAM_TIMEOUT: <<parameters.timeout>>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -5,10 +5,6 @@ docker:
   - image: cimg/openjdk:17.0
 
 parameters:
-  version:
-    type: string
-    description: 'The version of the underlying smack-sint-server-extensions jar file to use.'
-    default: '1.0'
   ipAddress:
     type: string
     description: 'The IP address of the server under test'
@@ -36,7 +32,6 @@ parameters:
 
 steps:
   - test:
-      version: << parameters.version >>
       ipAddress: << parameters.ipAddress >>
       domain: << parameters.domain >>
       timeout: << parameters.timeout >>

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+VERSION=1.0
+
 # Get variables from the environment
-VERSION=$(circleci env subst "${PARAM_VERSION}")
 IP_ADDRESS=$(circleci env subst "${PARAM_IP_ADDRESS}")
 DOMAIN=$(circleci env subst "${PARAM_DOMAIN}")
 TIMEOUT=$(circleci env subst "${PARAM_TIMEOUT}")


### PR DESCRIPTION
Although flexible, it also adds complexity. The Github Action sibling of this Orb doesn't have this either.