### PR TITLE
Update smack-sint-server-extensions to 1.2 and expose new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The Orb can be configured using the following inputs:
     adminAccountUsername: admin
     adminAccountPassword: password
     disabledTests: EntityCapsTest,SoftwareInfoIntegrationTest
+    disabledSpecifications: XEP-0352
+    logDir: ./logs
 ```
 
 ## Usage Example

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -22,6 +22,10 @@ parameters:
     type: string
     description: 'Password for the admin account.'
     default: ''
+  disabledSpecifications:
+    type: string
+    description: 'A comma-separated list of specifications (not case-sensitive) that are to be skipped. For example: XEP-0045,XEP-0060'
+    default: ''
   disabledTests:
     type: string
     description: 'Comma-separated list of tests that are to be skipped (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
@@ -35,6 +39,7 @@ steps:
         PARAM_TIMEOUT: <<parameters.timeout>>
         PARAM_ADMIN_ACCOUNT_USERNAME: <<parameters.adminAccountUsername>>
         PARAM_ADMIN_ACCOUNT_PASSWORD: <<parameters.adminAccountPassword>>
+        PARAM_DISABLED_SPECIFICATIONS: <<parameters.disabledSpecifications>>
         PARAM_DISABLED_TESTS: <<parameters.disabledTests>>
       name: Run Tests
       command: <<include(scripts/test.sh)>>

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -30,6 +30,10 @@ parameters:
     type: string
     description: 'Comma-separated list of tests that are to be skipped (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
     default: ''
+  logDir:
+    type: string
+    description: 'The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist.'
+    default: './output'
 
 steps:
   - run:
@@ -41,5 +45,6 @@ steps:
         PARAM_ADMIN_ACCOUNT_PASSWORD: <<parameters.adminAccountPassword>>
         PARAM_DISABLED_SPECIFICATIONS: <<parameters.disabledSpecifications>>
         PARAM_DISABLED_TESTS: <<parameters.disabledTests>>
+        PARAM_LOG_DIR: <<parameters.logDir>>
       name: Run Tests
       command: <<include(scripts/test.sh)>>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -25,6 +25,10 @@ parameters:
     type: string
     description: 'Password for the admin account.'
     default: ''
+  disabledSpecifications:
+    type: string
+    description: 'A comma-separated list of specifications (not case-sensitive) that are to be skipped. For example: XEP-0045,XEP-0060'
+    default: ''
   disabledTests:
     type: string
     description: 'Comma-separated list of tests that are to be skipped (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
@@ -37,4 +41,5 @@ steps:
       timeout: << parameters.timeout >>
       adminAccountUsername: << parameters.adminAccountUsername >>
       adminAccountPassword: << parameters.adminAccountPassword >>
+      disabledSpecifications: << parameters.disabledSpecifications >>
       disabledTests: << parameters.disabledTests >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -33,6 +33,10 @@ parameters:
     type: string
     description: 'Comma-separated list of tests that are to be skipped (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
     default: ''
+  logDir:
+    type: string
+    description: 'The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist.'
+    default: './output'
 
 steps:
   - test:
@@ -43,3 +47,4 @@ steps:
       adminAccountPassword: << parameters.adminAccountPassword >>
       disabledSpecifications: << parameters.disabledSpecifications >>
       disabledTests: << parameters.disabledTests >>
+      logDir: << parameters.logDir >>

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -8,6 +8,7 @@ DOMAIN=$(circleci env subst "${PARAM_DOMAIN}")
 TIMEOUT=$(circleci env subst "${PARAM_TIMEOUT}")
 ADMIN_ACCOUNT_USERNAME=$(circleci env subst "${PARAM_ADMIN_ACCOUNT_USERNAME}")
 ADMIN_ACCOUNT_PASSWORD=$(circleci env subst "${PARAM_ADMIN_ACCOUNT_PASSWORD}")
+DISABLED_SPECIFICATIONS=$(circleci env subst "${PARAM_DISABLED_SPECIFICATIONS}")
 DISABLED_TESTS=$(circleci env subst "${PARAM_DISABLED_TESTS}")
 
 # Download the JAR file
@@ -23,5 +24,6 @@ java \
     -Dsinttest.adminAccountPassword="$ADMIN_ACCOUNT_PASSWORD" \
     -Dsinttest.enabledConnections=tcp \
     -Dsinttest.dnsResolver=javax \
+    -Dsinttest.disabledSpecifications="$DISABLED_SPECIFICATIONS"  \
     -Dsinttest.disabledTests="$DISABLED_TESTS" \
     -jar "smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar"

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -10,6 +10,7 @@ ADMIN_ACCOUNT_USERNAME=$(circleci env subst "${PARAM_ADMIN_ACCOUNT_USERNAME}")
 ADMIN_ACCOUNT_PASSWORD=$(circleci env subst "${PARAM_ADMIN_ACCOUNT_PASSWORD}")
 DISABLED_SPECIFICATIONS=$(circleci env subst "${PARAM_DISABLED_SPECIFICATIONS}")
 DISABLED_TESTS=$(circleci env subst "${PARAM_DISABLED_TESTS}")
+LOG_DIR=$(circleci env subst "${PARAM_LOG_DIR}")
 
 # Download the JAR file
 curl -L "https://github.com/XMPP-Interop-Testing/smack-sint-server-extensions/releases/download/v$VERSION/smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar" -o "smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar"
@@ -26,4 +27,7 @@ java \
     -Dsinttest.dnsResolver=javax \
     -Dsinttest.disabledSpecifications="$DISABLED_SPECIFICATIONS"  \
     -Dsinttest.disabledTests="$DISABLED_TESTS" \
+    -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.SmackIntegrationTestFramework\$JulTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
+    -Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory" \
+    -DlogDir="$LOG_DIR" \
     -jar "smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar"

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=1.0
+VERSION=1.2
 
 # Get variables from the environment
 IP_ADDRESS=$(circleci env subst "${PARAM_IP_ADDRESS}")


### PR DESCRIPTION
By bumping smack-sint-server-extensions two versions, a couple of new features have become available.

I've attempted to expose these in individual commits, but I'm unsure _exactly_ what I'm doing here.

Assuming that we get this working, then it might be worthwhile to find out if we can use the junit-xml files that should now be generated to have an automatic report in CirclCI, but that's a bridge to far for this PR.[ I'll raise an issue for that](https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/issues/7).