### PR TITLE
Fix the naming of things

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -55,7 +55,7 @@ workflows:
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
-          orb_name: interop-test/tests
+          orb_name: xmpp-interop-tests/test
           vcs_type: << pipeline.project.type >>
           pub_type: production
           # There's no test of the job here, but that's just a wrapper for the command.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xmpp-interop-tests-circleci-orb
 
-[![CircleCI Build Status](https://circleci.com/gh/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/interop-test/tests.svg)](https://circleci.com/developer/orbs/orb/interop-test/tests) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI Build Status](https://circleci.com/gh/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/xmpp-interop-tests/test.svg)](https://circleci.com/developer/orbs/orb/xmpp-interop-test/test) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 A CircleCI Orb that performs XMPP interoperability tests on an XMPP domain.
 

--- a/src/examples/step.yml
+++ b/src/examples/step.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    xmpp-interop-tests: xmpp-interop-tests/tests@1.0.0
+    xmpp-interop-tests: xmpp-interop-tests/test@1.0.0
 
   jobs:
     build:


### PR DESCRIPTION
* Our namespace changed from 'interop-test' to 'xmpp-interop-tests'
* We want our orb to be 'test' not 'tests'

This PR makes everything 'xmpp-interop-tests/test'

Fixes #8

Tests will fail until #10 is merged and this is rebased.