### PR TITLE
Use SINT 'host' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following strategies for test account provisioning are supported:
 
 The Orb can be configured using the following inputs:
 
-- `ipAddress`: the IP address of the server under test. Default value: `127.0.0.1`
+- `host`: IP address or DNS name of the XMPP service to run the tests on. Default value: `127.0.0.1`
 - `domain`: the XMPP domain name of server under test. Default value: `example.org`
 - `timeout`: the amount of milliseconds after which an XMPP action (typically an IQ request) is considered timed out. Default value: `5000` (five seconds)
 - `adminAccountUsername`: _(optional)_ The account name of a pre-existing user that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html). If not provided, in-band registration ([XEP-0077](https://xmpp.org/extensions/xep-0077.html)) will be used to provision accounts.
@@ -37,7 +37,7 @@ The Orb can be configured using the following inputs:
 
 ```yaml
 - xmpp-interop-tests/test:
-    ipAddress: 127.0.0.1
+    host: 127.0.0.1
     domain: example.org
     timeout: 5000
     adminAccountUsername: admin
@@ -87,7 +87,7 @@ usage:
             command: ./my-server/run.sh
             background: true
         - xmpp-interop-tests/test:
-            ipAddress: 127.0.0.1
+            host: 127.0.0.1
             domain: example.org
             timeout: 5000
             adminAccountUsername: admin

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -2,9 +2,9 @@ description: >
   Runs tests using the provided configuration parameters
 
 parameters:
-  ipAddress:
+  host:
     type: string
-    description: 'The IP address of the server under test'
+    description: 'IP address or DNS name of the XMPP service to run the tests on.'
     default: '127.0.0.1'
   domain:
     type: string
@@ -38,7 +38,7 @@ parameters:
 steps:
   - run:
       environment:
-        PARAM_IP_ADDRESS: <<parameters.ipAddress>>
+        PARAM_HOST: <<parameters.host>>
         PARAM_DOMAIN: <<parameters.domain>>
         PARAM_TIMEOUT: <<parameters.timeout>>
         PARAM_ADMIN_ACCOUNT_USERNAME: <<parameters.adminAccountUsername>>

--- a/src/examples/step.yml
+++ b/src/examples/step.yml
@@ -24,7 +24,7 @@ usage:
             command: ./my-server/run.sh
             background: true
         - xmpp-interop-tests/test:
-            ipAddress: 127.0.0.1
+            host: 127.0.0.1
             domain: example.org
             timeout: 5000
             adminAccountUsername: admin

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -5,9 +5,9 @@ docker:
   - image: cimg/openjdk:17.0
 
 parameters:
-  ipAddress:
+  host:
     type: string
-    description: 'The IP address of the server under test'
+    description: 'IP address or DNS name of the XMPP service to run the tests on.'
     default: '127.0.0.1'
   domain:
     type: string
@@ -40,7 +40,7 @@ parameters:
 
 steps:
   - test:
-      ipAddress: << parameters.ipAddress >>
+      host: << parameters.host >>
       domain: << parameters.domain >>
       timeout: << parameters.timeout >>
       adminAccountUsername: << parameters.adminAccountUsername >>

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -3,7 +3,7 @@
 VERSION=1.2
 
 # Get variables from the environment
-IP_ADDRESS=$(circleci env subst "${PARAM_IP_ADDRESS}")
+HOST=$(circleci env subst "${PARAM_HOST}")
 DOMAIN=$(circleci env subst "${PARAM_DOMAIN}")
 TIMEOUT=$(circleci env subst "${PARAM_TIMEOUT}")
 ADMIN_ACCOUNT_USERNAME=$(circleci env subst "${PARAM_ADMIN_ACCOUNT_USERNAME}")
@@ -15,10 +15,9 @@ LOG_DIR=$(circleci env subst "${PARAM_LOG_DIR}")
 # Download the JAR file
 curl -L "https://github.com/XMPP-Interop-Testing/smack-sint-server-extensions/releases/download/v$VERSION/smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar" -o "smack-sint-server-extensions-$VERSION-jar-with-dependencies.jar"
 
-echo "$IP_ADDRESS $DOMAIN" | sudo tee -a /etc/hosts
-
 java \
     -Dsinttest.service="$DOMAIN" \
+    -Dsinttest.host="$HOST" \
     -Dsinttest.securityMode=disabled \
     -Dsinttest.replyTimeout="$TIMEOUT" \
     -Dsinttest.adminAccountUsername="$ADMIN_ACCOUNT_USERNAME" \


### PR DESCRIPTION
Recently, the Smack Integration Test Framework got a new configuration option, named 'host'. This allows the test to be configured with an IP address or DNS name of the XMPP service to run the tests on.

This new option negates the tricks involving setting `/etc/hosts` to make the XMPP domain name resolve to the intended host. This commit replaces that solution with the new configuration option.

Additionally, this commit renames the old 'ipAddress' configuration option to 'host', to improve consistency in nomenclature.