### PR TITLE
Update readme for upstream triggered releases

### DIFF
--- a/.github/workflows/upstream_release.yml
+++ b/.github/workflows/upstream_release.yml
@@ -38,9 +38,14 @@ jobs:
             echo "file_version=$FILE_VERSION" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Replace the version in the action.yml file
+      - name: Update the default version in the test.sh file
         run: |
             sed -i "s#VERSION=.*#VERSION=${{ steps.version.outputs.file_version }}#" src/scripts/test.sh
+        shell: bash
+       
+      - name: Update the version in the README file
+        run: |
+            sed -i "s#test@.*#test@${{ steps.version.outputs.version }}#g" README.md
         shell: bash
 
       - name: Create Pull Request


### PR DESCRIPTION
When smack-sint-server-extensions gets a release, the action in this repo is triggered.

When that happens, we want to update the repo's readme at the same time, since we match release numbers with the upstream.