### PR TITLE
Add config option for fail-on-impossible-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Orb can be configured using the following inputs:
 - `disabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are to be skipped. For example: `XEP-0045,XEP-0060`
 - `enabledTests`: _(optional)_ A comma-separated list of tests that are to be run. For example: `EntityCapsTest,SoftwareInfoIntegrationTest`
 - `enabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are to be run. For example: `XEP-0045,XEP-0060`
+- `failOnImpossibleTest`: _(optional)_ If set to 'true', fails the test run if any configured tests were impossible to execute. (default: 'false')
 - `logDir`: _(optional)_ The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist. Default value: `./output`
 
 ### Provisioning Test Accounts

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -62,6 +62,10 @@ parameters:
     type: string
     description: 'Comma-separated list of tests that are to be run (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
     default: ''
+  failOnImpossibleTest:
+    type: string
+    description: 'If set to "true", fails the test run if any configured tests were impossible to execute.'
+    default: 'false'
   logDir:
     type: string
     description: 'The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist.'
@@ -85,6 +89,7 @@ steps:
         PARAM_DISABLED_TESTS: <<parameters.disabledTests>>
         PARAM_ENABLED_SPECIFICATIONS: <<parameters.enabledSpecifications>>
         PARAM_ENABLED_TESTS: <<parameters.enabledTests>>
+        PARAM_FAIL_ON_IMPOSSIBLE_TEST: <<parameters.failOnImpossibleTest>>
         PARAM_LOG_DIR: <<parameters.logDir>>
       name: Run Tests
       command: <<include(scripts/test.sh)>>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -65,6 +65,10 @@ parameters:
     type: string
     description: 'Comma-separated list of tests that are to be run (eg: "EntityCapsTest,SoftwareInfoIntegrationTest")'
     default: ''
+  failOnImpossibleTest:
+    type: string
+    description: 'If set to "true", fails the test run if any configured tests were impossible to execute.'
+    default: 'false'
   logDir:
     type: string
     description: 'The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist.'
@@ -87,4 +91,5 @@ steps:
       disabledTests: << parameters.disabledTests >>
       enabledSpecifications: << parameters.enabledSpecifications >>
       enabledTests: << parameters.enabledTests >>
+      failOnImpossibleTest: << parameters.failOnImpossibleTest >>
       logDir: << parameters.logDir >>

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -18,6 +18,7 @@ DISABLED_SPECIFICATIONS=$(circleci env subst "${PARAM_DISABLED_SPECIFICATIONS}")
 DISABLED_TESTS=$(circleci env subst "${PARAM_DISABLED_TESTS}")
 ENABLED_SPECIFICATIONS=$(circleci env subst "${PARAM_ENABLED_SPECIFICATIONS}")
 ENABLED_TESTS=$(circleci env subst "${PARAM_ENABLED_TESTS}")
+FAIL_ON_IMPOSSIBLE_TEST=$(circleci env subst "${PARAM_FAIL_ON_IMPOSSIBLE_TEST}")
 LOG_DIR=$(circleci env subst "${PARAM_LOG_DIR}")
 
 # Download the JAR file
@@ -67,6 +68,9 @@ if [ "$ENABLED_SPECIFICATIONS" != "" ]; then
 fi
 if [ "$ENABLED_TESTS" != "" ]; then
     JAVACMD+=("-Dsinttest.enabledTests=$ENABLED_TESTS")
+fi
+if [ "$FAIL_ON_IMPOSSIBLE_TEST" != "" ]; then
+    JAVACMD+=("-Dsinttest.failOnImpossibleTest=$FAIL_ON_IMPOSSIBLE_TEST")
 fi
 JAVACMD+=("-Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor")
 JAVACMD+=("-Dsinttest.debugger=org.igniterealtime.smack.inttest.util.ModifiedStandardSinttestDebuggerMetaFactory")


### PR DESCRIPTION
Test may be impossible to run, for example, because the server that's being tested does not support a particular feature.

It is not unreasonable for users to assume that, upon a successful test execution result, all tests have passed. In the case of 'impossible' tests, this isn't necessarily the case: some test might not have executed at all.

Especially in scenarios where users have configured the test run to enable a specific subset of the tests (through configuration such as enabledTests and enabledSpecifications) it may be desirable to hard fail when a test was impossible to execute. This enforces that a test run was strictly successful in all tests it was configured to execute.

fixes #29