### PR TITLE
Add missing variable to upstream_release workflow

### DIFF
--- a/.github/workflows/upstream_release.yml
+++ b/.github/workflows/upstream_release.yml
@@ -34,6 +34,8 @@ jobs:
             FILE_VERSION="${VERSION:1}" # Strip leading 'v'
             echo "Version: $VERSION"
             echo "File version: $FILE_VERSION"
+
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "file_version=$FILE_VERSION" >> $GITHUB_OUTPUT
         shell: bash
 


### PR DESCRIPTION
#31 was created with a missing version in the title.

That's because the version was missing from the workflow.

That's because I deleted it in #26 :facepalm: 

This puts it back.